### PR TITLE
Improve behavior where chickens would fall below platforms

### DIFF
--- a/client/js/update.js
+++ b/client/js/update.js
@@ -52,6 +52,11 @@ var update = function(){
     addAnimations(otherChickens[key]);
   }
 
+  game.physics.arcade.overlap(player, platforms, function(playerSprite, platform) {
+    playerSprite.y = platform.top - (playerSprite.height/2) - 5;
+  });
+
+
   if(cursors.left.isDown && player.body.velocity.x > -playerMaxSpeed) {
     player.body.velocity.x -= playerAccleration;
     player.scale.x = 2;

--- a/client/js/update.js
+++ b/client/js/update.js
@@ -14,7 +14,6 @@ var update = function(){
   }
   syncTimer++;
 
-  game.physics.arcade.collide(player, platforms);
 
   // By waiting for the next sync before stopping, I believe this improves hit detection online
   if (stoppingTime + syncRate === syncTimer) {
@@ -44,17 +43,22 @@ var update = function(){
       stopping = right;
     }
     stoppingTime = syncTimer;
-  }
+  };
+
+  game.physics.arcade.collide(player, platforms);
+
+  // Ensure that players cannot go through the platforms if other players jump on them
+  game.physics.arcade.overlap(player, platforms, function(playerSprite, platform) {
+    var abovePlatform = platform.top - (playerSprite.height/2) - 5; // 5 is to offset player.js line 18
+    playerSprite.y = abovePlatform;
+  });
 
   for (var key in otherChickens) {
-    game.physics.arcade.collide(otherChickens[key], platforms);
     game.physics.arcade.collide(otherChickens[key], player, collideChickens);
+    game.physics.arcade.collide(otherChickens[key], platforms);
     addAnimations(otherChickens[key]);
   }
 
-  game.physics.arcade.overlap(player, platforms, function(playerSprite, platform) {
-    playerSprite.y = platform.top - (playerSprite.height/2) - 5;
-  });
 
 
   if(cursors.left.isDown && player.body.velocity.x > -playerMaxSpeed) {
@@ -135,4 +139,4 @@ var sendSync = function() {
   socket.emit('sync', {'PX': player.x, 'PY': player.y,
                        'VX': player.body.velocity.x, 'VY': player.body.velocity.y,
                        'dashBool': dashButton.isDown});
-}
+};


### PR DESCRIPTION
Related to #45 
- Added an overlap check that moves chickens above platforms if a player is overlapping with a platform

This improves the behavior where chickens would fall below platforms but does NOT completely fix it. 

Introduces a new bug: If the player hits the left/right side of a platform and overlaps (happens very rarely), the player will move above the platform
