### PR TITLE
Allow chicken sprite to move before deleting (in case it was paused)

### DIFF
--- a/client/js/create.js
+++ b/client/js/create.js
@@ -83,6 +83,7 @@ var create = function(){
       });
       for (var key in otherChickens) {
         if (syncKeys.indexOf(key) === -1) {
+          otherChickens[key].body.moves = true;
           delete otherChickens[key];
         }
       }


### PR DESCRIPTION
- Fixes the bug where lots of paused chicken sprites were remaining in games (even after the players had already d/ced)
